### PR TITLE
Insert Locale.US for localization independence

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-8
+target=android-19

--- a/project.properties
+++ b/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-8

--- a/src/com/brandontate/androidwebviewselection/BTWebView.java
+++ b/src/com/brandontate/androidwebviewselection/BTWebView.java
@@ -16,8 +16,11 @@
 
 package com.brandontate.androidwebviewselection;
 
+import java.util.Locale;
+
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -171,7 +174,7 @@ public class BTWebView extends WebView implements TextSelectionJavascriptInterfa
 
         if(event.getAction() == MotionEvent.ACTION_DOWN){
 
-            String startTouchUrl = String.format("javascript:android.selection.startTouch(%f, %f);",
+            String startTouchUrl = String.format(Locale.US,"javascript:android.selection.startTouch(%f, %f);",
                     xPoint, yPoint);
 
             mLastTouchX = xPoint;
@@ -532,12 +535,12 @@ public class BTWebView extends WebView implements TextSelectionJavascriptInterfa
 
 
         if(mLastTouchedSelectionHandle == SELECTION_START_HANDLE && startX > 0 && startY > 0){
-            String saveStartString = String.format("javascript: android.selection.setStartPos(%f, %f);", startX, startY);
+            String saveStartString = String.format(Locale.US,"javascript: android.selection.setStartPos(%f, %f);", startX, startY);
             loadUrl(saveStartString);
         }
 
         if(mLastTouchedSelectionHandle == SELECTION_END_HANDLE && endX > 0 && endY > 0){
-            String saveEndString = String.format("javascript: android.selection.setEndPos(%f, %f);", endX, endY);
+            String saveEndString = String.format(Locale.US,"javascript: android.selection.setEndPos(%f, %f);", endX, endY);
             loadUrl(saveEndString);
         }
 

--- a/src/com/brandontate/androidwebviewselection/BTWebView.java
+++ b/src/com/brandontate/androidwebviewselection/BTWebView.java
@@ -16,6 +16,8 @@
 
 package com.brandontate.androidwebviewselection;
 
+import java.util.Locale;
+
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
 import org.json.JSONException;
@@ -171,7 +173,7 @@ public class BTWebView extends WebView implements TextSelectionJavascriptInterfa
 
         if(event.getAction() == MotionEvent.ACTION_DOWN){
 
-            String startTouchUrl = String.format("javascript:android.selection.startTouch(%f, %f);",
+            String startTouchUrl = String.format(Locale.US, "javascript:android.selection.startTouch(%f, %f);",
                     xPoint, yPoint);
 
             mLastTouchX = xPoint;
@@ -532,12 +534,12 @@ public class BTWebView extends WebView implements TextSelectionJavascriptInterfa
 
 
         if(mLastTouchedSelectionHandle == SELECTION_START_HANDLE && startX > 0 && startY > 0){
-            String saveStartString = String.format("javascript: android.selection.setStartPos(%f, %f);", startX, startY);
+            String saveStartString = String.format(Locale.US, "javascript: android.selection.setStartPos(%f, %f);", startX, startY);
             loadUrl(saveStartString);
         }
 
         if(mLastTouchedSelectionHandle == SELECTION_END_HANDLE && endX > 0 && endY > 0){
-            String saveEndString = String.format("javascript: android.selection.setEndPos(%f, %f);", endX, endY);
+            String saveEndString = String.format(Locale.US, "javascript: android.selection.setEndPos(%f, %f);", endX, endY);
             loadUrl(saveEndString);
         }
 

--- a/src/com/brandontate/androidwebviewselection/BTWebView.java
+++ b/src/com/brandontate/androidwebviewselection/BTWebView.java
@@ -16,11 +16,8 @@
 
 package com.brandontate.androidwebviewselection;
 
-import java.util.Locale;
-
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -174,7 +171,7 @@ public class BTWebView extends WebView implements TextSelectionJavascriptInterfa
 
         if(event.getAction() == MotionEvent.ACTION_DOWN){
 
-            String startTouchUrl = String.format(Locale.US,"javascript:android.selection.startTouch(%f, %f);",
+            String startTouchUrl = String.format("javascript:android.selection.startTouch(%f, %f);",
                     xPoint, yPoint);
 
             mLastTouchX = xPoint;
@@ -535,12 +532,12 @@ public class BTWebView extends WebView implements TextSelectionJavascriptInterfa
 
 
         if(mLastTouchedSelectionHandle == SELECTION_START_HANDLE && startX > 0 && startY > 0){
-            String saveStartString = String.format(Locale.US,"javascript: android.selection.setStartPos(%f, %f);", startX, startY);
+            String saveStartString = String.format("javascript: android.selection.setStartPos(%f, %f);", startX, startY);
             loadUrl(saveStartString);
         }
 
         if(mLastTouchedSelectionHandle == SELECTION_END_HANDLE && endX > 0 && endY > 0){
-            String saveEndString = String.format(Locale.US,"javascript: android.selection.setEndPos(%f, %f);", endX, endY);
+            String saveEndString = String.format("javascript: android.selection.setEndPos(%f, %f);", endX, endY);
             loadUrl(saveEndString);
         }
 


### PR DESCRIPTION
In order to solve the problem of incompatibility with localized units of mesure in non english devices you should use Locale.US for default strings used internally.
